### PR TITLE
adding ignore list to entangled.toml file

### DIFF
--- a/template/entangled.toml
+++ b/template/entangled.toml
@@ -1,3 +1,4 @@
 version="2.0"
 watch_list=["docs/**/*.md"]
+ignore_list=["**/README.md"]
 


### PR DESCRIPTION
allows to override ignore_list in entangled default config. This PR is only needed one entangled PR #32 is merged. 